### PR TITLE
Fix fatal PHP error on line 55. "Unexpected ;"

### DIFF
--- a/opensrs/mail/mailSetDomainMailboxLimits.php
+++ b/opensrs/mail/mailSetDomainMailboxLimits.php
@@ -52,7 +52,7 @@ class mailSetDomainMailboxLimits extends openSRS_mail {
 				trigger_error ("oSRS-eMail Error - authentication domain is not defined.", E_USER_WARNING);
 				$allPassed = false;
 			} else {
-				$this->_dataObject->data->admin_domain = ;
+				$this->_dataObject->data->admin_domain = APP_MAIL_DOMAIN;
 			}
 		}
 						


### PR DESCRIPTION
For some reason a constant was missing from this line preventing me from using it, I'm presuming it wants to be the APP_MAIL_DOMAIN constant.

Changed
`$this->_dataObject->data->admin_domain = ;` 

to  

`$this->_dataObject->data->admin_domain = APP_MAIL_DOMAIN;`
