### PR TITLE
Added .NU / .SE gTLD support + reworked the DirectoryIterator to work with all versions of PHP5

### DIFF
--- a/opensrs/domains/provisioning/provModify.php
+++ b/opensrs/domains/provisioning/provModify.php
@@ -308,7 +308,9 @@ class provModify extends openSRS_base {
 			'protocol' => 'XCP',
 			'action' => 'modify',
 			'object' => 'DOMAIN',
-			'cookie' => $this->_dataObject->data->cookie,
+			/* Commented by BC : RA : 24-6-2014 : To set same XML call as lookupGetDomain */
+            /* 'cookie' => $this->_dataObject->data->cookie, */
+            /* End : To set same XML call as lookupGetDomain */
 			'attributes' => array (
 				'affect_domains' => $this->_dataObject->data->affect_domains,
 				'data' => $this->_dataObject->data->data

--- a/opensrs/domains/provisioning/provSWregister.php
+++ b/opensrs/domains/provisioning/provSWregister.php
@@ -43,10 +43,13 @@ class provSWregister extends openSRS_base {
         		$allPassed = $this->$_ccTLD();
  			  	/* Changed by BC : NG : 10-9-2014 : To hide notice displayed at register page for tld .asia */
                 /*trigger_error($tld . " needs special requirements.");*/
-                if($tld != "asia")
+                /* Changed by BC : NG : 8-10-2014 : To hide notice displayed at register page for tld .it */
+                /*if($tld != "asia")*/
+                if($tld != "asia" && $tld != "it")
                 {
                        trigger_error($tld . " needs special requirements.");
                 }
+                /* End : To hide notice displayed at register page for tld .it */
                 /* End : To hide notice displayed at register page for tld .asia */
       		}
 

--- a/opensrs/domains/provisioning/provSWregister.php
+++ b/opensrs/domains/provisioning/provSWregister.php
@@ -357,6 +357,15 @@ class provSWregister extends openSRS_base {
 		$xmlCMD = $this->_opsHandler->encode($cmd);					// Flip Array to XML
 		$XMLresult = $this->send_cmd($xmlCMD);						// Send XML
 		$arrayResult = $this->_opsHandler->decode($XMLresult);		// Flip XML to Array
+        
+        /* Added by BC : NG : 16-7-2014 : To set error message for Insufficient Funds */
+        if(isset($arrayResult['attributes']['forced_pending']) and $arrayResult['attributes']['forced_pending'] != "" and $arrayResult['is_success'] == 1)
+        {
+            $arrayResult['is_success'] = 0;
+            if($arrayResult['response_text'] == 'Registration successful')    // Get Resonse Text 'Registration successful'  when insufficient fund
+                $arrayResult['response_text'] = "Insufficient Funds";
+        }
+        /* End : To set error message for Insufficient Funds */
 
 		// Results
 		$this->resultFullRaw = $arrayResult;

--- a/opensrs/domains/provisioning/provSWregister.php
+++ b/opensrs/domains/provisioning/provSWregister.php
@@ -285,16 +285,31 @@ class provSWregister extends openSRS_base {
 			if (isSet($this->_dataObject->data->rant_no) && $this->_dataObject->data->rant_no != "") $cmd['attributes']['rant_no'] = $this->_dataObject->data->rant_no;
 		}
 		
-		if ($ccTLD == "asia") {
-			$reqDatas = array("contact_type", "id_number", "id_type", "legal_entity_type", "locality_country", "id_type_info", 
-				"legal_entity_type_info","locality_city", "locality_state_prov"
-			);
+		/* Changed by BC : NG : 9-9-2014 : To resolve issue of tld .asia registration error  */
+        
+        /*if ($ccTLD == "asia") {
+            $reqDatas = array("contact_type", "id_number", "id_type", "legal_entity_type", "locality_country", "id_type_info", 
+                "legal_entity_type_info","locality_city", "locality_state_prov"
+            );
 
-			foreach($reqDatasASIA as $reqData) {
-				if(isSet($this->_dataObject->cedinfo->data->$reqData) && $this->_dataObject->data->$reqData != "")
-					$cmd['attributes']['tld_data']['ced_info'][$reqData] = $this->_dataObject->data->$reqData;
-			}
-		}
+            foreach($reqDatasASIA as $reqData) {
+                if(isSet($this->_dataObject->cedinfo->data->$reqData) && $this->_dataObject->data->$reqData != "")
+                    $cmd['attributes']['tld_data']['ced_info'][$reqData] = $this->_dataObject->data->$reqData;
+            }
+        }*/
+        
+        if ($ccTLD == "asia") {
+            $reqDatasASIA = array("contact_type", "id_number", "id_type", "legal_entity_type", "locality_country", "id_type_info", 
+                "legal_entity_type_info","locality_city", "locality_state_prov"
+            );
+
+            foreach($reqDatasASIA as $reqData) {
+                if(isSet($this->_dataObject->cedinfo->$reqData) && $this->_dataObject->cedinfo->$reqData != "")
+                    $cmd['attributes']['tld_data']['ced_info'][$reqData] = $this->_dataObject->cedinfo->$reqData;
+            }
+        }
+        
+        /* END : To resolve issue of tld .asia registration error  */
 		
 		if ($ccTLD == "au") {
 			$reqDatasAU = array("registrant_name", "eligibility_type", "registrant_id", "registrant_id_type", "eligibility_name", 

--- a/opensrs/domains/provisioning/provSWregister.php
+++ b/opensrs/domains/provisioning/provSWregister.php
@@ -41,7 +41,13 @@ class provSWregister extends openSRS_base {
 			if (in_array($tld, $special_tlds)) {
 				$_ccTLD = "_ccTLD_" . $tld;
         		$allPassed = $this->$_ccTLD();
- 			  	trigger_error($tld . " needs special requirements.");
+ 			  	/* Changed by BC : NG : 10-9-2014 : To hide notice displayed at register page for tld .asia */
+                /*trigger_error($tld . " needs special requirements.");*/
+                if($tld != "asia")
+                {
+                       trigger_error($tld . " needs special requirements.");
+                }
+                /* End : To hide notice displayed at register page for tld .asia */
       		}
 
 			// Call the process function

--- a/opensrs/domains/provisioning/provSWregister.php
+++ b/opensrs/domains/provisioning/provSWregister.php
@@ -36,7 +36,7 @@ class provSWregister extends openSRS_base {
 			$allPassed = $this->_allTimeRequired ();
 
 			// The following TLDs require additional option values
-			$special_tlds = array("ca", "asia", "be", "de", "eu", "it", "name", "us", "au", "pro", "br");
+			$special_tlds = array("ca", "asia", "be", "de", "eu", "it", "name", "us", "au", "pro", "br", "nu", "se");
 
 			if (in_array($tld, $special_tlds)) {
 				$_ccTLD = "_ccTLD_" . $tld;
@@ -229,6 +229,54 @@ class provSWregister extends openSRS_base {
 		return $subtest;
 	}
 	
+	private function _ccTLD_nu () {
+		$subtest = true;
+		$reqDatas = array("registrant_type");
+		foreach($reqDatas as $reqData) {
+			if ($this->_dataObject->registrant_extra_info->$reqData == "") {
+				trigger_error ("oSRS Error - ". $reqData ." is not defined.", E_USER_WARNING);
+				$subtest = false;
+			}
+			else
+			{
+				if ($reqData == "registrant_type" && $this->_dataObject->registrant_extra_info->$reqData == 'individual')
+				{
+					$reqDatas[] = 'id_card_number';
+				}
+				else
+				{
+					$reqDatas[] = 'registrant_vat_id';
+					$reqDatas[] = 'registration_number';
+				} 
+			}
+		}
+		return $subtest;
+	}
+	
+	private function _ccTLD_se () {
+		$subtest = true;
+		$reqDatas = array("registrant_type");
+		foreach($reqDatas as $reqData) {
+			if ($this->_dataObject->registrant_extra_info->$reqData == "") {
+				trigger_error ("oSRS Error - ". $reqData ." is not defined.", E_USER_WARNING);
+				$subtest = false;
+			}
+			else
+			{
+				if ($reqData == "registrant_type" && $this->_dataObject->registrant_extra_info->$reqData == 'individual')
+				{
+					$reqDatas[] = 'id_card_number';
+				}
+				else
+				{
+					$reqDatas[] = 'registrant_vat_id';
+					$reqDatas[] = 'registration_number';
+				} 
+			}
+		}
+		return $subtest;
+	}
+	
 	// Post validation functions
 	private function _processRequest ($ccTLD){
 		// Compile the command	
@@ -372,6 +420,30 @@ class provSWregister extends openSRS_base {
 			$cmd['attributes']['tld_data']['nexus']['app_purpose'] = $this->_dataObject->nexus->app_purpose;
 			$cmd['attributes']['tld_data']['nexus']['category'] = $this->_dataObject->nexus->category;
 			if (isSet($this->_dataObject->nexus->validator) && $this->_dataObject->nexus->validator != "") $cmd['attributes']['tld_data']['nexus']['validator'] = $this->_dataObject->nexus->validator;
+		}
+		if ($ccTLD == "nu") {
+			$cmd['attributes']['tld_data']['registrant_extra_info']['registrant_type'] = $this->_dataObject->registrant_extra_info->registrant_type;
+			if ($this->_dataObject->registrant_extra_info->registrant_type == 'individual')
+			{
+				$cmd['attributes']['tld_data']['registrant_extra_info']['id_card_number'] = $this->_dataObject->registrant_extra_info->id_card_number;
+			}
+			else
+			{
+				$cmd['attributes']['tld_data']['registrant_extra_info']['registrant_vat_id'] = $this->_dataObject->registrant_extra_info->registrant_vat_id;
+				$cmd['attributes']['tld_data']['registrant_extra_info']['registration_number'] = $this->_dataObject->registrant_extra_info->registration_number;
+			}
+		}
+		if ($ccTLD == "se") {
+			$cmd['attributes']['tld_data']['registrant_extra_info']['registrant_type'] = $this->_dataObject->registrant_extra_info->registrant_type;
+			if ($this->_dataObject->registrant_extra_info->registrant_type == 'individual')
+			{
+				$cmd['attributes']['tld_data']['registrant_extra_info']['id_card_number'] = $this->_dataObject->registrant_extra_info->id_card_number;
+			}
+			else
+			{
+				$cmd['attributes']['tld_data']['registrant_extra_info']['registrant_vat_id'] = $this->_dataObject->registrant_extra_info->registrant_vat_id;
+				$cmd['attributes']['tld_data']['registrant_extra_info']['registration_number'] = $this->_dataObject->registrant_extra_info->registration_number;
+			}
 		}
 
 		if ($ccTLD == "pro") {

--- a/opensrs/domains/provisioning/provSWregister.php
+++ b/opensrs/domains/provisioning/provSWregister.php
@@ -47,10 +47,13 @@ class provSWregister extends openSRS_base {
                 /*if($tld != "asia")*/   
                 /* Changed by BC : NG : 11-2-2015 : To resolve issue for tld .EU domain registration */
                 /*if($tld != "asia" && $tld != "it")*/
-                if($tld != "asia" && $tld != "it" && $tld != "eu")
+                /* Changed by BC : NG : 21-2-2014 : To hide notice displayed at register page for tld .de */ 
+                /*if($tld != "asia" && $tld != "it" && $tld != "eu")*/
+                if($tld != "asia" && $tld != "it" && $tld != "eu" && $tld != "de")
                 {
                        trigger_error($tld . " needs special requirements.");
                 }
+                /* End: To hide notice displayed at register page for tld .de */
                 /* End : To resolve issue for tld .EU domain registration */
                 /* End : To hide notice displayed at register page for tld .it */
                 /* End : To hide notice displayed at register page for tld .asia */

--- a/opensrs/domains/provisioning/provSWregister.php
+++ b/opensrs/domains/provisioning/provSWregister.php
@@ -44,11 +44,14 @@ class provSWregister extends openSRS_base {
  			  	/* Changed by BC : NG : 10-9-2014 : To hide notice displayed at register page for tld .asia */
                 /*trigger_error($tld . " needs special requirements.");*/
                 /* Changed by BC : NG : 8-10-2014 : To hide notice displayed at register page for tld .it */
-                /*if($tld != "asia")*/
-                if($tld != "asia" && $tld != "it")
+                /*if($tld != "asia")*/   
+                /* Changed by BC : NG : 11-2-2015 : To resolve issue for tld .EU domain registration */
+                /*if($tld != "asia" && $tld != "it")*/
+                if($tld != "asia" && $tld != "it" && $tld != "eu")
                 {
                        trigger_error($tld . " needs special requirements.");
                 }
+                /* End : To resolve issue for tld .EU domain registration */
                 /* End : To hide notice displayed at register page for tld .it */
                 /* End : To hide notice displayed at register page for tld .asia */
       		}

--- a/opensrs/domains/provisioning/provUpdateContacts.php
+++ b/opensrs/domains/provisioning/provUpdateContacts.php
@@ -72,7 +72,7 @@ class provUpdateContacts extends openSRS_base {
         return $userArray;
     }*/  
     
-    private function _createUserData($type){
+    private function _createUserData($type = null){
         switch ($type) {
           case "admin":
             $userArray = array(

--- a/opensrs/domains/provisioning/provUpdateContacts.php
+++ b/opensrs/domains/provisioning/provUpdateContacts.php
@@ -24,7 +24,17 @@ class provUpdateContacts extends openSRS_base {
 		$allPassed = true;
 
 		// Personal information
-		$reqPers = array ("first_name", "last_name", "org_name", "address1", "city", "state", "country", "postal_code", "phone", "email", "lang_pref");
+        /* Changed by BC : NG : 2-5-2015 : To resolve issue for tld .NL  */
+		//$reqPers = array ("first_name", "last_name", "org_name", "address1", "city", "state", "country", "postal_code", "phone", "email", "lang_pref");
+        if($tld == "nl")
+        {
+            $reqPers = array ("first_name", "last_name", "org_name", "address1", "city", "country", "postal_code", "phone", "email", "lang_pref");
+        }
+        else
+        {
+            $reqPers = array ("first_name", "last_name", "org_name", "address1", "city", "state", "country", "postal_code", "phone", "email", "lang_pref");
+        }
+        /* End : To resolve issue for tld .NL  */
 		for ($i = 0; $i < count($reqPers); $i++){
 			if ($this->_dataObject->personal->$reqPers[$i] == "") {
 				trigger_error ("oSRS Error - ". $reqPers[$i] ." is not defined.", E_USER_WARNING);

--- a/opensrs/domains/provisioning/provUpdateContacts.php
+++ b/opensrs/domains/provisioning/provUpdateContacts.php
@@ -49,47 +49,154 @@ class provUpdateContacts extends openSRS_base {
 		}		
 	}
 
-	private function _createUserData(){
-		$userArray = array(
-			"first_name" => $this->_dataObject->personal->first_name,
-			"last_name" => $this->_dataObject->personal->last_name,
-			"org_name" => $this->_dataObject->personal->org_name,
-			"address1" => $this->_dataObject->personal->address1,
-			"address2" => $this->_dataObject->personal->address2,
-			"address3" => $this->_dataObject->personal->address3,
-			"city" => $this->_dataObject->personal->city,
-			"state" => $this->_dataObject->personal->state,
-			"postal_code" => $this->_dataObject->personal->postal_code,
-			"country" => $this->_dataObject->personal->country,
-			"phone" => $this->_dataObject->personal->phone,
-			"fax" => $this->_dataObject->personal->fax,
-			"email" => $this->_dataObject->personal->email,
-			"url" => $this->_dataObject->personal->url,
-			"lang_pref" => $this->_dataObject->personal->lang_pref
-		);
-		return $userArray;
-	}	
+	/* Changed by BC : NG : 23-7-2014 : To resolve issue of save/update all contact details  */ 
+    
+    /*private function _createUserData(){
+        $userArray = array(
+            "first_name" => $this->_dataObject->personal->first_name,
+            "last_name" => $this->_dataObject->personal->last_name,
+            "org_name" => $this->_dataObject->personal->org_name,
+            "address1" => $this->_dataObject->personal->address1,
+            "address2" => $this->_dataObject->personal->address2,
+            "address3" => $this->_dataObject->personal->address3,
+            "city" => $this->_dataObject->personal->city,
+            "state" => $this->_dataObject->personal->state,
+            "postal_code" => $this->_dataObject->personal->postal_code,
+            "country" => $this->_dataObject->personal->country,
+            "phone" => $this->_dataObject->personal->phone,
+            "fax" => $this->_dataObject->personal->fax,
+            "email" => $this->_dataObject->personal->email,
+            "url" => $this->_dataObject->personal->url,
+            "lang_pref" => $this->_dataObject->personal->lang_pref
+        );
+        return $userArray;
+    }*/  
+    
+    private function _createUserData($type){
+        switch ($type) {
+          case "admin":
+            $userArray = array(
+                "first_name" => $this->_dataObject->admin->first_name,
+                "last_name" => $this->_dataObject->admin->last_name,
+                "org_name" => $this->_dataObject->admin->org_name,
+                "address1" => $this->_dataObject->admin->address1,
+                "address2" => $this->_dataObject->admin->address2,
+                "address3" => $this->_dataObject->admin->address3,
+                "city" => $this->_dataObject->admin->city,
+                "state" => $this->_dataObject->admin->state,
+                "postal_code" => $this->_dataObject->admin->postal_code,
+                "country" => $this->_dataObject->admin->country,
+                "phone" => $this->_dataObject->admin->phone,
+                "fax" => $this->_dataObject->admin->fax,
+                "email" => $this->_dataObject->admin->email,
+                "url" => $this->_dataObject->admin->url,
+                "lang_pref" => $this->_dataObject->admin->lang_pref
+            );
+            return $userArray;
+            break;
+          case "billing":
+           $userArray = array(
+                "first_name" => $this->_dataObject->billing->first_name,
+                "last_name" => $this->_dataObject->billing->last_name,
+                "org_name" => $this->_dataObject->billing->org_name,
+                "address1" => $this->_dataObject->billing->address1,
+                "address2" => $this->_dataObject->billing->address2,
+                "address3" => $this->_dataObject->billing->address3,
+                "city" => $this->_dataObject->billing->city,
+                "state" => $this->_dataObject->billing->state,
+                "postal_code" => $this->_dataObject->billing->postal_code,
+                "country" => $this->_dataObject->billing->country,
+                "phone" => $this->_dataObject->billing->phone,
+                "fax" => $this->_dataObject->billing->fax,
+                "email" => $this->_dataObject->billing->email,
+                "url" => $this->_dataObject->billing->url,
+                "lang_pref" => $this->_dataObject->billing->lang_pref
+            );
+            return $userArray;
+            break;
+          case "tech":
+            $userArray = array(
+                "first_name" => $this->_dataObject->tech->first_name,
+                "last_name" => $this->_dataObject->tech->last_name,
+                "org_name" => $this->_dataObject->tech->org_name,
+                "address1" => $this->_dataObject->tech->address1,
+                "address2" => $this->_dataObject->tech->address2,
+                "address3" => $this->_dataObject->tech->address3,
+                "city" => $this->_dataObject->tech->city,
+                "state" => $this->_dataObject->tech->state,
+                "postal_code" => $this->_dataObject->tech->postal_code,
+                "country" => $this->_dataObject->tech->country,
+                "phone" => $this->_dataObject->tech->phone,
+                "fax" => $this->_dataObject->tech->fax,
+                "email" => $this->_dataObject->tech->email,
+                "url" => $this->_dataObject->tech->url,
+                "lang_pref" => $this->_dataObject->tech->lang_pref
+            );
+            return $userArray;
+            break;
+          case "personal":          
+          default:
+            $userArray = array(
+                "first_name" => $this->_dataObject->personal->first_name,
+                "last_name" => $this->_dataObject->personal->last_name,
+                "org_name" => $this->_dataObject->personal->org_name,
+                "address1" => $this->_dataObject->personal->address1,
+                "address2" => $this->_dataObject->personal->address2,
+                "address3" => $this->_dataObject->personal->address3,
+                "city" => $this->_dataObject->personal->city,
+                "state" => $this->_dataObject->personal->state,
+                "postal_code" => $this->_dataObject->personal->postal_code,
+                "country" => $this->_dataObject->personal->country,
+                "phone" => $this->_dataObject->personal->phone,
+                "fax" => $this->_dataObject->personal->fax,
+                "email" => $this->_dataObject->personal->email,
+                "url" => $this->_dataObject->personal->url,
+                "lang_pref" => $this->_dataObject->personal->lang_pref
+            );
+            return $userArray;
+        }
+    }
+    /* End : To resolve issue of save/update all contact details */   
 	
 	// Post validation functions
 	private function processRequest (){
 		$this->_dataObject->data->types = explode (",", $this->_dataObject->data->types);
 	
 		// Compile the command
-		$cmd = array(
-			'protocol' => 'XCP',
-			'action' => 'update_contacts',
-			'object' => 'domain',
-			'attributes' => array(
-				'domain' => $this->_dataObject->data->domain,
-				'types' => $this->_dataObject->data->types,
-				'contact_set' => array(
-					'owner' => $this->_createUserData(),
-					'admin' => $this->_createUserData(),
-					'billing' => $this->_createUserData(),
-					'tech' => $this->_createUserData()
-				)
-			)
-		);
+		/* Changed by BC : NG : 23-7-2014 : To resolve issue of save/update all contact details  */ 
+        
+        /*$cmd = array(
+            'protocol' => 'XCP',
+            'action' => 'update_contacts',
+            'object' => 'domain',
+            'attributes' => array(
+                'domain' => $this->_dataObject->data->domain,
+                'types' => $this->_dataObject->data->types,
+                'contact_set' => array(
+                    'owner' => $this->_createUserData(),
+                    'admin' => $this->_createUserData(),
+                    'billing' => $this->_createUserData(),
+                    'tech' => $this->_createUserData()
+                )
+            )
+        );*/
+        
+        $cmd = array(
+            'protocol' => 'XCP',
+            'action' => 'update_contacts',
+            'object' => 'domain',
+            'attributes' => array(
+                'domain' => $this->_dataObject->data->domain,
+                'types' => $this->_dataObject->data->types,
+                'contact_set' => array(
+                    'owner' => $this->_createUserData('personal'),
+                    'admin' => $this->_createUserData('admin'),
+                    'billing' => $this->_createUserData('billing'),
+                    'tech' => $this->_createUserData('tech')
+                )
+            )
+        );
+        /* End : To resolve issue of save/update all contact details */
 
 		$xmlCMD = $this->_opsHandler->encode($cmd);					// Flip Array to XML
 		$XMLresult = $this->send_cmd($xmlCMD);						// Send XML

--- a/opensrs/openSRS_fastlookup.php
+++ b/opensrs/openSRS_fastlookup.php
@@ -64,7 +64,9 @@ class openSRS_fastlookup {
 
 			$callCheck = "check_domain ". $domain . $tld;
 			$callLength = strlen($callCheck);
-			echo $callCheck . "<br/>";
+            /* Commented by BC : NG : 1-12-2014 : To solve issue in fast look up */
+			//echo $callCheck . "<br/>";
+            /* End : To solve issue in fast look up */
 			fputs($this->_socket, $callCheck, $callLength );
 
 //			// wait 0.25 sec - Immediate socket read will result for wait loops and longer response

--- a/opensrs/openSRS_loader.php
+++ b/opensrs/openSRS_loader.php
@@ -18,12 +18,13 @@ final class Autoloader
   static public function load_domains( $classname )
   {
     $iterator = new DirectoryIterator(OPENSRSDOMAINS);
-    foreach($iterator as $dir){
-    	if($dir->isDot()) continue;
-      $classfile = OPENSRSDOMAINS . DS . $dir . DS . $classname . ".php";
+    while($iterator->valid()){
+    	if($iterator->isDot()) continue;
+      $classfile = OPENSRSDOMAINS . DS . $iterator->getFilename() . DS . $classname . ".php";
     	if(file_exists( $classfile )) {
       	require_once $classfile;
     	}
+		$iterator->next();
     }
   }
 }

--- a/opensrs/openSRS_loader.php
+++ b/opensrs/openSRS_loader.php
@@ -6,26 +6,26 @@ final class Autoloader
 {
   static public function load( $classname )
   {
-    $lib_paths = array(OPENSRSURI, OPENSRSMAIL, OPENSRSOMA, OPENSRSFASTLOOKUP, OPENSRSTRUST);
-    
-    foreach ($lib_paths as &$path) {
-    	$classfile = $path . DS . $classname . ".php";
-    	if(file_exists( $classfile )) {
-      	require_once $classfile;
-    	}
-  	}
+	$lib_paths = array(OPENSRSURI, OPENSRSMAIL, OPENSRSOMA, OPENSRSFASTLOOKUP, OPENSRSTRUST);
+	
+	foreach ($lib_paths as &$path) {
+		$classfile = $path . DS . $classname . ".php";
+		if(file_exists( $classfile )) {
+		require_once $classfile;
+		}
+	}
   } 
   static public function load_domains( $classname )
   {
-    $iterator = new DirectoryIterator(OPENSRSDOMAINS);
-    while($iterator->valid()){
-    	if($iterator->isDot()) continue;
-      $classfile = OPENSRSDOMAINS . DS . $iterator->getFilename() . DS . $classname . ".php";
-    	if(file_exists( $classfile )) {
-      	require_once $classfile;
-    	}
+	$iterator = new DirectoryIterator(OPENSRSDOMAINS);
+	while($iterator->valid()) {
+		$file = $iterator->current();
+		$classfile = OPENSRSDOMAINS . DS . $file->getFilename() . DS . $classname . ".php";
+		if(!$iterator->isDot() && file_exists( $classfile )) {
+			require_once $classfile;
+		}
 		$iterator->next();
-    }
+	}
   }
 }
 
@@ -46,10 +46,10 @@ function array2object($data) {
   $object = new stdClass();
   
   foreach ($data as $name=>$value) {
-    if (isset($name)) {
-      $name = strtolower(trim($name));
-      $object->$name = array2object($value); 
-    }
+	if (isset($name)) {
+	  $name = strtolower(trim($name));
+	  $object->$name = array2object($value); 
+	}
   }
   return $object;
 }
@@ -63,37 +63,37 @@ function object2array($data){
 // Call parsers and functions of openSRS
 function processOpenSRS ($type="", $data="") {
 
-    if (empty($data)) {
-        trigger_error("OSRS Error - No data found.");
-        return null;
-    }
-    else {
-        $dataArray = array();
-        switch(strtolower($type)) {
-            case "array":
-                $dataArray = $data;
-                break;
-            case "json":
-                $json = str_replace("\\\"", "\"", $data);   //  Replace  \"  with " for JSON that comes from Javascript
-                $dataArray = json_decode($json, true);
-                break;
-            case "yaml":
-                $dataArray = Spyc::YAMLLoad($data);
-                break;
-            default:
-                $dataArray = $data;
-        }
-		    // Convert associative array to object
-        $dataObject = array2object($dataArray);
-        $classCall = null;
-        if (class_exists($dataObject->func)){
-            $classCall = new $dataObject->func($type, $dataObject);
-        } 
-        else {
-            trigger_error("OSRS Error - Unable to find the function $dataObject->func.  Either the function is misspelled or there are incorrect file paths set in openSRS_config.php.");
-        }
-        return $classCall;
-    }
+	if (empty($data)) {
+		trigger_error("OSRS Error - No data found.");
+		return null;
+	}
+	else {
+		$dataArray = array();
+		switch(strtolower($type)) {
+			case "array":
+				$dataArray = $data;
+				break;
+			case "json":
+				$json = str_replace("\\\"", "\"", $data);   //  Replace  \"  with " for JSON that comes from Javascript
+				$dataArray = json_decode($json, true);
+				break;
+			case "yaml":
+				$dataArray = Spyc::YAMLLoad($data);
+				break;
+			default:
+				$dataArray = $data;
+		}
+			// Convert associative array to object
+		$dataObject = array2object($dataArray);
+		$classCall = null;
+		if (class_exists($dataObject->func)){
+			$classCall = new $dataObject->func($type, $dataObject);
+		} 
+		else {
+			trigger_error("OSRS Error - Unable to find the function $dataObject->func.  Either the function is misspelled or there are incorrect file paths set in openSRS_config.php.");
+		}
+		return $classCall;
+	}
 }
 
 function convertArray2Formatted ($type="", $data="") {
@@ -114,10 +114,10 @@ function array_filter_recursive($input)
 {
   foreach ($input as &$value)
   {
-    if (is_array($value))
-    {
-      $value = array_filter_recursive($value);
-    }
+	if (is_array($value))
+	{
+	  $value = array_filter_recursive($value);
+	}
   } 
   return array_filter($input);
 }


### PR DESCRIPTION
Some versions of PHP like 5.2 dont properly implement the ability to
simply foreach loop the Iterator.

Heres an example:
//   /home contains 3 directories:   larry, curly, moe
$d = new DirectoryIterator('/home');
foreach ($d as $i)
    echo "$i";

PHP 5.2 output:
larry
larry
larry

PHP 5.3+ output:
larry
curly
moe

The DirectoryIterator is still very usable with its class calls, so I reworked the code like this:

$d = new DirectoryIterator('/home');
while($d->valid()) {
	echo $d->getFilename();
	$d->next();
}

The new code will work with all versions of PHP5+