### PR TITLE
Make $this->_SESSID a number as expected rather than hex

### DIFF
--- a/opensrs/Ops.php
+++ b/opensrs/Ops.php
@@ -33,7 +33,7 @@ class Ops
             }
         }
 
-        $this->_SESSID = uniqid();
+        $this->_SESSID = microtime(true);
         $this->_MSGCNT = 0;
     }
 


### PR DESCRIPTION
On any recent PHP, sending anything produces a notice like:

> PHP Notice:  A non well formed numeric value encountered in vendor/opensrs/osrs-toolkit-php/opensrs/Ops.php on line 196

That's because it's trying to add a hex string to a number - because uniqid() in its current form produces hex:

```
$ php -r'echo uniqid()."\n";'
5b0e9bd2145ce
$
```

Since the source data for uniqid() is just the timestamp (us) and OpenSRS is clearly happy with a floating-point number for `<msg_id>`, directly using the timestamp fixes this.