### PR TITLE
Bugfixing string and integer addition for PHP 7.x

### DIFF
--- a/opensrs/Ops.php
+++ b/opensrs/Ops.php
@@ -193,7 +193,7 @@ class Ops
     public function encode($array)
     {
         ++$this->_MSGCNT;
-        $msg_id = $this->_SESSID + $this->_MSGCNT;            /* addition removes the leading zero */
+        $msg_id = intval($this->_SESSID) + $this->_MSGCNT;            /* addition removes the leading zero */
         $msg_type = $this->_MSGTYPE_STD;
 
         if ($array['protocol']) {


### PR DESCRIPTION
Current version of library does not work with PHP 7.x. With this fix backwards compatibility won't be broken but code will work.