### PR TITLE
Fix for removing false and 0 values from array

### DIFF
--- a/opensrs/openSRS_loader.php
+++ b/opensrs/openSRS_loader.php
@@ -89,5 +89,9 @@ function array_filter_recursive($input)
         }
     }
 
-    return array_filter($input);
+    return array_filter($input, 'is_not_null');
+}
+
+function is_not_null($value) {
+    return !is_null($value);
 }


### PR DESCRIPTION
The `array_filter` function in `array_filter_recursive` strips all `0` and `false` values which breaks bunch of API calls ie. when enabling previously disabled email domain using:

`['disabled' => false]`

This pull request filters out the `null` values, but keeps `false` and `0`